### PR TITLE
Prevent the popup from being opened in a new window when using shift key to copy the stream URL

### DIFF
--- a/extension/js/popup.js
+++ b/extension/js/popup.js
@@ -324,6 +324,7 @@ document.addEventListener("DOMContentLoaded", function() {
   })
 
   $("#copy").addEventListener("click", function(e) {
+    e.preventDefault()
     cmd = $("#cmd")
     if (e.shiftKey) {
       // copy only the URL if the shift key is held


### PR DESCRIPTION
I discovered that when using the shift key in MS Edge to copy only the URL, a new window would pop up. This fixes that.