### PR TITLE
Manifest Version 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ The extension performs all of its network requests through the host page, using 
 
 Firefox has better error handling in its `chrome.scripting.executeScript()` implementation and populates an [`error`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting/executeScript#error) key in the `InjectionResult` if an error was raised in the script. An [issue](https://bugs.chromium.org/p/chromium/issues/detail?id=1271527) has been filed to hopefully get the same support in Chrome.
 
-Due to this, where appropriate, return values from `executeScript` are an object with `result` or `error` keys depending on what happened. This looks funky but will have to do until the situation in Chrome improves.
+Due to this, where appropriate, return values from `executeScript` are an object with `result` or `error` keys depending on what happened. The complicated scripts are also wrapped in a `try-catch` clause. This looks funky but will have to do until the situation in Chrome improves.

--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ The extension performs all of its network requests through the host page, using 
 
 ### `executeScript` error handling
 
-Due to [a Chrome bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1271527), it isn't possible to throw an exception inside of `chrome.scripting.executeScript()` and receive the exception outside of the script.
+Firefox has better error handling in its `chrome.scripting.executeScript()` implementation and populates an [`error`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting/executeScript#error) key in the `InjectionResult` if an error was raised in the script. An [issue](https://bugs.chromium.org/p/chromium/issues/detail?id=1271527) has been filed to hopefully get the same support in Chrome.
 
-As a workaround, where appropriate, return values from `executeScript` are an object with `result` or `error` keys depending on what happened. This looks funky but will have to do until the Chrome bug is fixed.
-
-This is not a problem in Firefox.
+Due to this, where appropriate, return values from `executeScript` are an object with `result` or `error` keys depending on what happened. This looks funky but will have to do until the situation in Chrome improves.

--- a/README.md
+++ b/README.md
@@ -33,3 +33,11 @@ Or just download the file and put it there manually.
 ### Formatting
 
 The JavaScript code is formatted with prettier. The HTML is formatted with the built-in VS Code formatter.
+
+### Why are there more `executeScript` calls than seems necessary?
+
+The extension performs all of its network requests through the host page, using `chrome.scripting.executeScript()`, for a number of reasons:
+
+1. Any `POST` request made in the extension will cause Chrome to add an `Origin: chrome-extension://jhjhnecocacdbhlkjgpdacoibidhmgdf` header. This header is easy to detect and block by websites (see [#185](https://github.com/stefansundin/privatkopiera/issues/185)). By making the network request from the host page instead, the `Origin` header will look normal from the website's point of view. There's [a Chrome bug](https://bugs.chromium.org/p/chromium/issues/detail?id=966223) about this.
+2. The extension can avoid asking for host permissions when the user uses Privatkopiera on a website for the first time. This makes for a better experience since granting new permissions is not foolproof and at least one user reported that they didn't understand how to proceed (see [#184](https://github.com/stefansundin/privatkopiera/issues/184)).
+3. Some websites have permissive CORS permissions initially, but then later make it more restrictive. This makes for an impossible situation since the only workaround would be to ask for host permissions prematurely, even though they may not be required at the time.

--- a/README.md
+++ b/README.md
@@ -41,3 +41,11 @@ The extension performs all of its network requests through the host page, using 
 1. Any `POST` request made in the extension will cause Chrome to add an `Origin: chrome-extension://jhjhnecocacdbhlkjgpdacoibidhmgdf` header. This header is easy to detect and block by websites (see [#185](https://github.com/stefansundin/privatkopiera/issues/185)). By making the network request from the host page instead, the `Origin` header will look normal from the website's point of view. There's [a Chrome bug](https://bugs.chromium.org/p/chromium/issues/detail?id=966223) about this.
 2. The extension can avoid asking for host permissions when the user uses Privatkopiera on a website for the first time. This makes for a better experience since granting new permissions is not foolproof and at least one user reported that they didn't understand how to proceed (see [#184](https://github.com/stefansundin/privatkopiera/issues/184)).
 3. Some websites have permissive CORS permissions initially, but then later make it more restrictive. This makes for an impossible situation since the only workaround would be to ask for host permissions prematurely, even though they may not be required at the time.
+
+### `executeScript` error handling
+
+Due to [a Chrome bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1271527), it isn't possible to throw an exception inside of `chrome.scripting.executeScript()` and receive the exception outside of the script.
+
+As a workaround, where appropriate, return values from `executeScript` are an object with `result` or `error` keys depending on what happened. This looks funky but will have to do until the Chrome bug is fixed.
+
+This is not a problem in Firefox.

--- a/extension/js/popup.js
+++ b/extension/js/popup.js
@@ -26,6 +26,7 @@ export const options = {
 };
 
 export const subtitles = [];
+export let tab_id;
 let tab_url, url, site;
 
 export function update_filename(fn) {
@@ -395,6 +396,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+    tab_id = tabs[0].id;
     tab_url = tabs[0].url;
     if (!tab_url) {
       // https://stackoverflow.com/questions/28786723/why-doesnt-chrome-tabs-query-return-the-tabs-url-when-called-using-requirejs

--- a/extension/js/popup.js
+++ b/extension/js/popup.js
@@ -128,11 +128,7 @@ export function update_cmd(e) {
   streams.title = stream_fn;
   if (stream_ext === 'f4m') {
     cmd.value = `php AdobeHDS.php --delete --manifest "${url}" --outfile "${fn}"`;
-  } else if (
-    stream_ext === 'm4a' ||
-    stream_ext === 'mp3' ||
-    /^https?:\/\/http-live\.sr\.se/.test(url)
-  ) {
+  } else if (stream_ext === 'm4a' || stream_ext === 'mp3') {
     cmd.value = url;
     $('#copy').classList.add('d-none');
     $('#download').classList.remove('d-none');

--- a/extension/js/popup.js
+++ b/extension/js/popup.js
@@ -358,10 +358,15 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (!granted) {
       return;
     }
-    chrome.downloads.download({
-      url: $('#cmd').value,
-      filename: $('#filename').value,
-    });
+    try {
+      $('#download').disabled = true;
+      await chrome.downloads.download({
+        url: $('#cmd').value,
+        filename: $('#filename').value,
+      });
+    } finally {
+      $('#download').disabled = false;
+    }
   });
 
   const cmd = $('#cmd');

--- a/extension/js/popup.js
+++ b/extension/js/popup.js
@@ -299,7 +299,7 @@ async function call_func() {
   }
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
   $('#extension_version').textContent = `v${
     chrome.runtime.getManifest().version
   }`;
@@ -335,38 +335,33 @@ document.addEventListener('DOMContentLoaded', () => {
     chrome.runtime.openOptionsPage();
   });
 
-  $('#grant_permissions').addEventListener('click', () => {
-    chrome.permissions.request(site.permissions, (granted) => {
-      // The popup is automatically closed, so this does not really matter
-      // It stays open if "Inspect Popup" is used
-      if (granted) {
-        $('#copy').classList.remove('d-none');
-        $('#grant_permissions').classList.add('d-none');
-        $('#streams').disabled = false;
-        $('#filename').disabled = false;
-        $('#cmd').disabled = false;
-        call_func();
-      } else {
-        info('Fel: Behörigheter ej beviljade.');
-      }
-    });
+  $('#grant_permissions').addEventListener('click', async () => {
+    const granted = await chrome.permissions.request(site.permissions);
+    // The popup is automatically closed, so this does not really matter
+    // It stays open if "Inspect Popup" is used
+    if (granted) {
+      $('#copy').classList.remove('d-none');
+      $('#grant_permissions').classList.add('d-none');
+      $('#streams').disabled = false;
+      $('#filename').disabled = false;
+      $('#cmd').disabled = false;
+      call_func();
+    } else {
+      info('Fel: Behörigheter ej beviljade.');
+    }
   });
 
-  $('#download').addEventListener('click', () => {
-    chrome.permissions.request(
-      {
-        permissions: ['downloads'],
-      },
-      (granted) => {
-        if (!granted) {
-          return;
-        }
-        chrome.downloads.download({
-          url: $('#cmd').value,
-          filename: $('#filename').value,
-        });
-      },
-    );
+  $('#download').addEventListener('click', async () => {
+    const granted = await chrome.permissions.request({
+      permissions: ['downloads'],
+    });
+    if (!granted) {
+      return;
+    }
+    chrome.downloads.download({
+      url: $('#cmd').value,
+      filename: $('#filename').value,
+    });
   });
 
   const cmd = $('#cmd');
@@ -395,50 +390,50 @@ document.addEventListener('DOMContentLoaded', () => {
       });
   }
 
-  chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-    tab_id = tabs[0].id;
-    tab_url = tabs[0].url;
-    if (!tab_url) {
-      // https://stackoverflow.com/questions/28786723/why-doesnt-chrome-tabs-query-return-the-tabs-url-when-called-using-requirejs
-      // https://bugs.chromium.org/p/chromium/issues/detail?id=462939
-      // https://bugs.chromium.org/p/chromium/issues/detail?id=1005701
-      info(
-        'Unable to get the tab URL. Try closing all devtools and open the popup without inspecting it.',
-      );
-      return;
-    }
-    if (
-      tab_url.startsWith(
-        'chrome-extension://klbibkeccnjlkjkiokjodocebajanakg/suspended.html',
-      )
-    ) {
-      // Tab suspended with The Great Suspender. Your mileage may vary.
-      tab_url = tab_url.split('&uri=')[1];
-    }
-    url = new URL(tab_url);
-    $('#url').value = tab_url;
-    console.log(tab_url);
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  tab_id = tab.id;
+  tab_url = tab.url;
 
-    if ((site = matchers.find((m) => m.re.test(tab_url)))) {
-      if (site.permissions) {
-        chrome.permissions.contains(site.permissions, (granted) => {
-          if (granted) {
-            call_func();
-          } else {
-            $('#copy').classList.add('d-none');
-            $('#grant_permissions').classList.remove('d-none');
-            $('#streams').disabled = true;
-            $('#filename').disabled = true;
-            $('#cmd').disabled = true;
-            info('Fler behörigheter krävs för den här sidan.');
-          }
-        });
-        return;
-      } else {
+  if (!tab_url) {
+    // https://stackoverflow.com/questions/28786723/why-doesnt-chrome-tabs-query-return-the-tabs-url-when-called-using-requirejs
+    // https://bugs.chromium.org/p/chromium/issues/detail?id=462939
+    // https://bugs.chromium.org/p/chromium/issues/detail?id=1005701
+    info(
+      'Unable to get the tab URL. Try closing all devtools and open the popup without inspecting it.',
+    );
+    return;
+  }
+  if (
+    tab_url.startsWith(
+      'chrome-extension://klbibkeccnjlkjkiokjodocebajanakg/suspended.html',
+    )
+  ) {
+    // Tab suspended with The Great Suspender. Your mileage may vary.
+    tab_url = tab_url.split('&uri=')[1];
+  }
+  url = new URL(tab_url);
+  $('#url').value = tab_url;
+  console.log(tab_url);
+
+  site = matchers.find((m) => m.re.test(tab_url));
+  if (site) {
+    if (site.permissions) {
+      const granted = await chrome.permissions.contains(site.permissions);
+      if (granted) {
         call_func();
+      } else {
+        $('#copy').classList.add('d-none');
+        $('#grant_permissions').classList.remove('d-none');
+        $('#streams').disabled = true;
+        $('#filename').disabled = true;
+        $('#cmd').disabled = true;
+        info('Fler behörigheter krävs för den här sidan.');
       }
+      return;
     } else {
-      info('Fel: Den här hemsidan stöds ej.');
+      call_func();
     }
-  });
+  } else {
+    info('Fel: Den här hemsidan stöds ej.');
+  }
 });

--- a/extension/js/popup.js
+++ b/extension/js/popup.js
@@ -198,7 +198,7 @@ export function update_cmd(e) {
 
 export function master_callback(length, base_url) {
   return function (text) {
-    console.log(text);
+    console.debug(text);
 
     const ext_x_media = {};
     const streams = [];
@@ -207,7 +207,7 @@ export function master_callback(length, base_url) {
       if (line.length === 0) {
         continue;
       }
-      console.log(line);
+      console.debug(line);
       if (line.startsWith('#')) {
         if (!line.includes(':')) continue;
         const type = line.substring(1, line.indexOf(':'));
@@ -225,7 +225,7 @@ export function master_callback(length, base_url) {
             return [k, v];
           }),
         );
-        console.log(obj);
+        console.debug(obj);
         if (type === 'EXT-X-MEDIA') {
           // && obj["TYPE"] === "AUDIO") {
           ext_x_media[obj['TYPE']] = obj;
@@ -244,7 +244,7 @@ export function master_callback(length, base_url) {
         });
       }
     }
-    console.log(streams);
+    console.debug(streams);
 
     const dropdown = $('#streams');
     const default_option = dropdown.getElementsByTagName('option')[0];

--- a/extension/js/sites/dr.dk.js
+++ b/extension/js/sites/dr.dk.js
@@ -49,7 +49,12 @@ export default [
         target: { tabId: tab_id },
         func: () => [document.title, localStorage['session.tokens']],
       });
-      console.log('injectionResult', injectionResult);
+      console.debug('injectionResult', injectionResult);
+      if (injectionResult[0].error) {
+        throw injectionResult[0].error;
+      } else if (injectionResult[0].result === null) {
+        throw new Error('Script injection error.');
+      }
       const tabResult = injectionResult[0].result;
       const title = tabResult[0].split('|')[0].trim();
       const tokens = JSON.parse(tabResult[1]);

--- a/extension/js/sites/dr.dk.js
+++ b/extension/js/sites/dr.dk.js
@@ -5,6 +5,7 @@ import {
   api_error,
   options,
   subtitles,
+  tab_id,
   update_cmd,
   update_filename,
 } from '../popup.js';
@@ -43,38 +44,35 @@ export default [
     permissions: {
       origins: ['https://production.dr-massive.com/'],
     },
-    func: (ret) => {
+    func: async (ret) => {
       const video_id = ret[1];
       console.log(video_id);
 
       // Grab the page title and the required token from the page's localStorage
-      chrome.tabs.executeScript(
-        {
-          code: `(function(){
-            return [document.title, localStorage["session.tokens"]];
-          })()`,
-        },
-        function (data) {
-          console.log(data);
-          const title = data[0][0].split('|')[0].trim();
-          const tokens = JSON.parse(data[0][1]);
-          console.log(tokens);
-          const token = tokens.find((t) => t.type === 'UserAccount').value;
+      const injectionResult = await chrome.scripting.executeScript({
+        target: { tabId: tab_id },
+        func: () => [document.title, localStorage['session.tokens']],
+      });
+      console.log('injectionResult', injectionResult);
+      const tabResult = injectionResult[0].result;
 
-          const data_url = `https://production.dr-massive.com/api/account/items/${video_id}/videos?delivery=stream&device=web_browser&ff=idp%2Cldp%2Crpt&lang=da&resolution=HD-1080&sub=Anonymous`;
-          update_filename(`${title}.${options.default_video_file_extension}`);
+      const title = tabResult[0].split('|')[0].trim();
+      const tokens = JSON.parse(tabResult[1]);
+      console.log(tokens);
+      const token = tokens.find((t) => t.type === 'UserAccount').value;
 
-          console.log(data_url);
-          fetch(data_url, {
-            headers: {
-              'x-authorization': `Bearer ${token}`,
-            },
-          })
-            .then(get_json)
-            .then(dr_dk_callback)
-            .catch(api_error);
+      const data_url = `https://production.dr-massive.com/api/account/items/${video_id}/videos?delivery=stream&device=web_browser&ff=idp%2Cldp%2Crpt&lang=da&resolution=HD-1080&sub=Anonymous`;
+      update_filename(`${title}.${options.default_video_file_extension}`);
+
+      console.log(data_url);
+      fetch(data_url, {
+        headers: {
+          'x-authorization': `Bearer ${token}`,
         },
-      );
+      })
+        .then(get_json)
+        .then(dr_dk_callback)
+        .catch(api_error);
     },
   },
 ];

--- a/extension/js/sites/dr.dk.js
+++ b/extension/js/sites/dr.dk.js
@@ -53,7 +53,7 @@ export default [
       if (injectionResult[0].error) {
         throw injectionResult[0].error;
       } else if (injectionResult[0].result === null) {
-        throw new Error('Script injection error.');
+        throw new Error('Script error.');
       }
       const tabResult = injectionResult[0].result;
       const title = tabResult[0].split('|')[0].trim();

--- a/extension/js/sites/dr.dk.js
+++ b/extension/js/sites/dr.dk.js
@@ -2,14 +2,13 @@
 // https://production.dr-massive.com/api/account/items/242600/videos?delivery=stream&device=web_browser&ff=idp%2Cldp%2Crpt&lang=da&resolution=HD-1080&sub=Anonymous
 
 import {
-  api_error,
   options,
   subtitles,
   tab_id,
   update_cmd,
   update_filename,
 } from '../popup.js';
-import { $, extract_filename, get_json } from '../utils.js';
+import { $, extract_filename, fetchJson } from '../utils.js';
 
 function dr_dk_callback(streams) {
   const dropdown = $('#streams');
@@ -41,12 +40,9 @@ function dr_dk_callback(streams) {
 export default [
   {
     re: /^https?:\/\/(?:www\.)?dr\.dk\.?\/.*_(\d+)/,
-    permissions: {
-      origins: ['https://production.dr-massive.com/'],
-    },
     func: async (ret) => {
       const video_id = ret[1];
-      console.log(video_id);
+      console.log('video_id', video_id);
 
       // Grab the page title and the required token from the page's localStorage
       const injectionResult = await chrome.scripting.executeScript({
@@ -55,24 +51,22 @@ export default [
       });
       console.log('injectionResult', injectionResult);
       const tabResult = injectionResult[0].result;
-
       const title = tabResult[0].split('|')[0].trim();
       const tokens = JSON.parse(tabResult[1]);
-      console.log(tokens);
+      console.log('tokens', tokens);
       const token = tokens.find((t) => t.type === 'UserAccount').value;
 
       const data_url = `https://production.dr-massive.com/api/account/items/${video_id}/videos?delivery=stream&device=web_browser&ff=idp%2Cldp%2Crpt&lang=da&resolution=HD-1080&sub=Anonymous`;
+      console.log(data_url);
       update_filename(`${title}.${options.default_video_file_extension}`);
 
-      console.log(data_url);
-      fetch(data_url, {
+      const streams = await fetchJson(data_url, {
         headers: {
+          accept: 'application/json',
           'x-authorization': `Bearer ${token}`,
         },
-      })
-        .then(get_json)
-        .then(dr_dk_callback)
-        .catch(api_error);
+      });
+      await dr_dk_callback(streams);
     },
   },
 ];

--- a/extension/js/sites/nrk.js
+++ b/extension/js/sites/nrk.js
@@ -73,7 +73,7 @@ async function nrk_callback(data) {
   update_cmd();
 }
 
-function nrk_postcast_callback(data) {
+function nrk_podcast_callback(data) {
   console.log(data);
   const streams = $('#streams');
   for (const [i, asset] of data.playable.assets.entries()) {
@@ -124,16 +124,14 @@ export default [
           // accept: 'application/vnd.nrk.psapi+json; version=9; player=radio-web-player; device=player-core',
         },
       });
-      await nrk_postcast_callback(data);
+      await nrk_podcast_callback(data);
     },
   },
   {
     re: /^https?:\/\/radio\.nrk\.no\.?\/serie\/.+\/(l_[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b)/,
     func: async (ret) => {
-      // https://radio.nrk.no/podkast/bjoernen_lyver/l_709fe866-13a5-498d-9fe8-6613a5d98d1f
-      // https://psapi.nrk.no/playback/metadata/l_709fe866-13a5-498d-9fe8-6613a5d98d1f
-      // https://psapi.nrk.no/playback/manifest/podcast/l_68cb20c7-5a8c-4031-8b20-c75a8c003183
-      const data_url = `https://psapi.nrk.no/playback/manifest/podcast/${ret[1]}`;
+      // https://radio.nrk.no/serie/tett-paa-norske-artister/sesong/2018/MYNF51000518
+      const data_url = `https://psapi.nrk.no/playback/manifest/program/${ret[1]}`;
       console.log(data_url);
       update_json_url(data_url);
 
@@ -144,7 +142,7 @@ export default [
           // accept: 'application/vnd.nrk.psapi+json; version=9; player=radio-web-player; device=player-core',
         },
       });
-      await nrk_postcast_callback(data);
+      await nrk_podcast_callback(data);
     },
   },
   {

--- a/extension/js/sites/nrk.js
+++ b/extension/js/sites/nrk.js
@@ -166,7 +166,7 @@ export default [
       if (injectionResult[0].error) {
         throw injectionResult[0].error;
       } else if (injectionResult[0].result === null) {
-        throw new Error('Script injection error.');
+        throw new Error('Script error.');
       } else if (injectionResult[0].result.error) {
         throw new Error(injectionResult[0].result.error);
       }

--- a/extension/js/sites/nrk.js
+++ b/extension/js/sites/nrk.js
@@ -157,13 +157,20 @@ export default [
           // <div id="series-program-id-container" data-program-id="MSPO30080518">
           const div = document.querySelector('[data-program-id]');
           if (!div) {
-            return null;
+            return { error: 'data-program-id not found on page' };
           }
-          return div.getAttribute('data-program-id');
+          return { result: div.getAttribute('data-program-id') };
         },
       });
-      console.log('injectionResult', injectionResult);
-      const video_id = injectionResult[0].result;
+      console.debug('injectionResult', injectionResult);
+      if (injectionResult[0].error) {
+        throw injectionResult[0].error;
+      } else if (injectionResult[0].result === null) {
+        throw new Error('Script injection error.');
+      } else if (injectionResult[0].result.error) {
+        throw new Error(injectionResult[0].result.error);
+      }
+      const video_id = injectionResult[0].result.result;
 
       const data_url = `https://psapi.nrk.no/playback/manifest/program/${video_id}`;
       update_filename(`${video_id}.${options.default_video_file_extension}`);

--- a/extension/js/sites/nrk.js
+++ b/extension/js/sites/nrk.js
@@ -21,6 +21,7 @@ import {
   master_callback,
   options,
   subtitles,
+  tab_id,
   update_cmd,
   update_filename,
   update_json_url,
@@ -28,7 +29,6 @@ import {
 import {
   $,
   extract_filename,
-  flatten,
   get_json,
   get_text,
   getDocumentTitle,
@@ -68,7 +68,7 @@ async function nrk_callback(data) {
   if (data.sourceMedium === 'audio') {
     ext = options.default_audio_file_extension;
   }
-  const title = await getDocumentTitle();
+  const title = await getDocumentTitle(tab_id);
   if (title) {
     const fn = `${title}.${ext}`;
     update_filename(fn);
@@ -134,32 +134,28 @@ export default [
     permissions: {
       origins: ['https://psapi.nrk.no/'],
     },
-    func: () => {
+    func: async () => {
       // <div id="series-program-id-container" data-program-id="MSPO30080518">
-      chrome.tabs.executeScript(
-        {
-          code: `(function(){
-            const div = document.querySelector("[data-program-id]");
-            if (!div) {
-              return null;
-            }
-            return div.getAttribute("data-program-id");
-          })()`,
+      const injectionResult = await chrome.scripting.executeScript({
+        target: { tabId: tab_id },
+        func: () => {
+          const div = document.querySelector('[data-program-id]');
+          if (!div) {
+            return null;
+          }
+          return div.getAttribute('data-program-id');
         },
-        (ids) => {
-          console.log(ids);
-          flatten(ids).forEach((video_id) => {
-            const data_url = `https://psapi.nrk.no/playback/manifest/program/${video_id}`;
-            update_filename(
-              `${video_id}.${options.default_video_file_extension}`,
-            );
-            update_json_url(data_url);
+      });
+      console.log('injectionResult', injectionResult);
+      const tabResult = injectionResult[0].result;
 
-            console.log(data_url);
-            fetch(data_url).then(get_json).then(nrk_callback).catch(api_error);
-          });
-        },
-      );
+      const video_id = tabResult;
+      const data_url = `https://psapi.nrk.no/playback/manifest/program/${video_id}`;
+      update_filename(`${video_id}.${options.default_video_file_extension}`);
+      update_json_url(data_url);
+
+      console.log(data_url);
+      fetch(data_url).then(get_json).then(nrk_callback).catch(api_error);
     },
   },
 ];

--- a/extension/js/sites/nrk.js
+++ b/extension/js/sites/nrk.js
@@ -17,8 +17,9 @@
 // https://podkast.nrk.no/fil/bjoernen_lyver/bjoernen_lyver_2018-02-16_1300_760.MP3
 
 import {
-  master_callback,
+  api_error,
   options,
+  processPlaylist,
   subtitles,
   tab_id,
   update_cmd,
@@ -29,7 +30,6 @@ import {
   $,
   extract_filename,
   fetchJson,
-  fetchText,
   getDocumentTitle,
   parse_pt,
 } from '../utils.js';
@@ -45,9 +45,7 @@ async function nrk_callback(data) {
     option.appendChild(document.createTextNode(extract_filename(asset.url)));
     streams.appendChild(option);
 
-    const base_url = asset.url.replace(/\/[^/]+$/, '/');
-    const data = await fetchText(asset.url);
-    master_callback(duration, base_url)(data);
+    processPlaylist(asset.url, duration).catch(api_error);
   }
 
   for (const subtitle of data.playable.subtitles) {

--- a/extension/js/sites/sverigesradio.js
+++ b/extension/js/sites/sverigesradio.js
@@ -66,11 +66,18 @@ export default [
               title: title,
             });
           }
-          return streams;
+          return { result: streams };
         },
       });
-      console.log('injectionResult', injectionResult);
-      const streams = injectionResult[0].result;
+      console.debug('injectionResult', injectionResult);
+      if (injectionResult[0].error) {
+        throw injectionResult[0].error;
+      } else if (injectionResult[0].result === null) {
+        throw new Error('Script injection error.');
+      } else if (injectionResult[0].result.error) {
+        throw new Error(injectionResult[0].result.error);
+      }
+      const streams = injectionResult[0].result.result;
 
       for (const stream of streams) {
         const data_url = `https://sverigesradio.se/playerajax/getaudiourl?id=${stream.id}&type=${stream.type}&quality=high&format=iis`;

--- a/extension/js/sites/sverigesradio.js
+++ b/extension/js/sites/sverigesradio.js
@@ -9,14 +9,8 @@
 // Get audio URL:
 // https://sverigesradio.se/sida/playerajax/getaudiourl?id=5678841&type=clip&quality=high&format=iis
 
-import { api_error, update_cmd, update_json_url } from '../popup.js';
-import {
-  $,
-  extract_extension,
-  flatten,
-  get_json,
-  isFirefox,
-} from '../utils.js';
+import { api_error, tab_id, update_cmd, update_json_url } from '../popup.js';
+import { $, extract_extension, get_json, isFirefox } from '../utils.js';
 
 function sr_callback(stream, option) {
   return function (data) {
@@ -36,65 +30,70 @@ export default [
           origins: ['https://sverigesradio.se/'],
         }
       : null,
-    func: () => {
+    func: async () => {
       // Find audio streams by looking for data-audio-id attributes
-      chrome.tabs.executeScript(
-        {
-          code: `(function(){
-            const ids = [];
-            const streams = [];
-            const related = document.getElementsByTagName("article")[0].querySelectorAll("[data-audio-id]");
-            for (let i=0; i < related.length; i++) {
-              const link = related[i];
-              const id = link.getAttribute("data-audio-id");
-              if (ids.includes(id)) {
-                continue;
-              }
-              ids.push(id);
-              let header = link;
-              while (header.children.length < 2) {
-                header = header.parentNode;
-              }
-              let title = document.title;
-              const title_element = header.getElementsByClassName("main-audio-new__title")[0] || header.getElementsByClassName("related-audio__title")[0] || header.getElementsByClassName("article-audio-details__header-title")[0];
-              if (title_element) {
-                title = title_element.textContent.trim();
-              }
-              else {
-                const dash = title.lastIndexOf("-");
-                if (dash !== -1) {
-                  title = title.substring(0, dash).trim();
-                }
-              }
-              streams.push({
-                id: id,
-                type: link.getAttribute("data-audio-type"),
-                title: title,
-              });
+      const injectionResult = await chrome.scripting.executeScript({
+        target: { tabId: tab_id },
+        func: () => {
+          const ids = [];
+          const streams = [];
+          const related = document
+            .getElementsByTagName('article')[0]
+            .querySelectorAll('[data-audio-id]');
+          for (let i = 0; i < related.length; i++) {
+            const link = related[i];
+            const id = link.getAttribute('data-audio-id');
+            if (ids.includes(id)) {
+              continue;
             }
-            return streams;
-          })()`,
+            ids.push(id);
+            let header = link;
+            while (header.children.length < 2) {
+              header = header.parentNode;
+            }
+            let title = document.title;
+            const title_element =
+              header.getElementsByClassName('main-audio-new__title')[0] ||
+              header.getElementsByClassName('related-audio__title')[0] ||
+              header.getElementsByClassName(
+                'article-audio-details__header-title',
+              )[0];
+            if (title_element) {
+              title = title_element.textContent.trim();
+            } else {
+              const dash = title.lastIndexOf('-');
+              if (dash !== -1) {
+                title = title.substring(0, dash).trim();
+              }
+            }
+            streams.push({
+              id: id,
+              type: link.getAttribute('data-audio-type'),
+              title: title,
+            });
+          }
+          return streams;
         },
-        function (streams) {
-          const dropdown = $('#streams');
-          console.log(streams);
-          flatten(streams).forEach(function (stream) {
-            // Create the option here so we always get them in the same order
-            const option = document.createElement('option');
-            option.appendChild(document.createTextNode(stream.title));
-            dropdown.appendChild(option);
+      });
+      console.log('injectionResult', injectionResult);
+      const tabResult = injectionResult[0].result;
 
-            const data_url = `https://sverigesradio.se/playerajax/getaudiourl?id=${stream.id}&type=${stream.type}&quality=high&format=iis`;
-            update_json_url(data_url);
+      const dropdown = $('#streams');
+      for (const stream of tabResult) {
+        // Create the option here so we always get them in the same order
+        const option = document.createElement('option');
+        option.appendChild(document.createTextNode(stream.title));
+        dropdown.appendChild(option);
 
-            console.log(data_url);
-            fetch(data_url)
-              .then(get_json)
-              .then(sr_callback(stream, option))
-              .catch(api_error);
-          });
-        },
-      );
+        const data_url = `https://sverigesradio.se/playerajax/getaudiourl?id=${stream.id}&type=${stream.type}&quality=high&format=iis`;
+        update_json_url(data_url);
+
+        console.log(data_url);
+        fetch(data_url)
+          .then(get_json)
+          .then(sr_callback(stream, option))
+          .catch(api_error);
+      }
     },
   },
 ];

--- a/extension/js/sites/sverigesradio.js
+++ b/extension/js/sites/sverigesradio.js
@@ -73,7 +73,7 @@ export default [
       if (injectionResult[0].error) {
         throw injectionResult[0].error;
       } else if (injectionResult[0].result === null) {
-        throw new Error('Script injection error.');
+        throw new Error('Script error.');
       } else if (injectionResult[0].result.error) {
         throw new Error(injectionResult[0].result.error);
       }

--- a/extension/js/sites/sverigesradio.js
+++ b/extension/js/sites/sverigesradio.js
@@ -29,44 +29,48 @@ export default [
       const injectionResult = await chrome.scripting.executeScript({
         target: { tabId: tab_id },
         func: () => {
-          const ids = [];
-          const streams = [];
-          const related = document
-            .getElementsByTagName('article')[0]
-            .querySelectorAll('[data-audio-id]');
-          for (let i = 0; i < related.length; i++) {
-            const link = related[i];
-            const id = link.getAttribute('data-audio-id');
-            if (ids.includes(id)) {
-              continue;
-            }
-            ids.push(id);
-            let header = link;
-            while (header.children.length < 2) {
-              header = header.parentNode;
-            }
-            let title = document.title;
-            const title_element =
-              header.getElementsByClassName('main-audio-new__title')[0] ||
-              header.getElementsByClassName('related-audio__title')[0] ||
-              header.getElementsByClassName(
-                'article-audio-details__header-title',
-              )[0];
-            if (title_element) {
-              title = title_element.textContent.trim();
-            } else {
-              const dash = title.lastIndexOf('-');
-              if (dash !== -1) {
-                title = title.substring(0, dash).trim();
+          try {
+            const ids = [];
+            const streams = [];
+            const related = document
+              .getElementsByTagName('article')[0]
+              .querySelectorAll('[data-audio-id]');
+            for (let i = 0; i < related.length; i++) {
+              const link = related[i];
+              const id = link.getAttribute('data-audio-id');
+              if (ids.includes(id)) {
+                continue;
               }
+              ids.push(id);
+              let header = link;
+              while (header.children.length < 2) {
+                header = header.parentNode;
+              }
+              let title = document.title;
+              const title_element =
+                header.getElementsByClassName('main-audio-new__title')[0] ||
+                header.getElementsByClassName('related-audio__title')[0] ||
+                header.getElementsByClassName(
+                  'article-audio-details__header-title',
+                )[0];
+              if (title_element) {
+                title = title_element.textContent.trim();
+              } else {
+                const dash = title.lastIndexOf('-');
+                if (dash !== -1) {
+                  title = title.substring(0, dash).trim();
+                }
+              }
+              streams.push({
+                id: id,
+                type: link.getAttribute('data-audio-type'),
+                title: title,
+              });
             }
-            streams.push({
-              id: id,
-              type: link.getAttribute('data-audio-type'),
-              title: title,
-            });
+            return { result: streams };
+          } catch (err) {
+            return { error: err.message };
           }
-          return { result: streams };
         },
       });
       console.debug('injectionResult', injectionResult);

--- a/extension/js/sites/sverigesradio.js
+++ b/extension/js/sites/sverigesradio.js
@@ -7,7 +7,7 @@
 // Get audio URL:
 // https://sverigesradio.se/sida/playerajax/getaudiourl?id=5678841&type=clip&quality=high&format=iis
 
-import { tab_id, update_cmd, update_json_url } from '../popup.js';
+import { info, tab_id, update_cmd, update_json_url } from '../popup.js';
 import { $, extract_extension, fetchJson } from '../utils.js';
 
 function sr_callback(stream, data) {
@@ -32,9 +32,10 @@ export default [
           try {
             const ids = [];
             const streams = [];
-            const related = document
-              .getElementsByTagName('article')[0]
-              .querySelectorAll('[data-audio-id]');
+            const related =
+              document
+                .getElementsByTagName('article')[0]
+                ?.querySelectorAll('[data-audio-id]') ?? [];
             for (let i = 0; i < related.length; i++) {
               const link = related[i];
               const id = link.getAttribute('data-audio-id');
@@ -93,6 +94,10 @@ export default [
           },
         });
         sr_callback(stream, data);
+      }
+
+      if (streams.length === 0) {
+        info('Hittade ingenting. Försök från en artikel.');
       }
     },
   },

--- a/extension/js/sites/svt.js
+++ b/extension/js/sites/svt.js
@@ -59,8 +59,8 @@ import {
 import {
   $,
   extract_filename,
-  fetchDOM,
   fetchJson,
+  fetchNextData,
   fetchText,
 } from '../utils.js';
 
@@ -181,10 +181,7 @@ export default [
   {
     re: /^https?:\/\/(?:www\.)?svt\.se\.?\/recept\//,
     func: async (ret, url) => {
-      const doc = await fetchDOM(url);
-      const data = JSON.parse(doc.querySelector('#__NEXT_DATA__').textContent);
-      console.log(data);
-
+      const data = await fetchNextData(url);
       const videoIds = Object.values(data.props.pageProps.__APOLLO_STATE__)
         .map((v) => v.videoId)
         .filter(Boolean);

--- a/extension/js/sites/svt.js
+++ b/extension/js/sites/svt.js
@@ -56,7 +56,15 @@ import {
   update_filename,
   update_json_url,
 } from '../popup.js';
-import { $, extract_filename, flatten, get_json, get_text } from '../utils.js';
+import {
+  $,
+  extract_filename,
+  fetchDOM,
+  flatten,
+  get_json,
+  get_text,
+  isFirefox,
+} from '../utils.js';
 
 function svt_callback(data) {
   console.log(data);
@@ -155,36 +163,31 @@ export default [
   },
   {
     re: /^https?:\/\/(?:www\.)?svt\.se\.?\/recept\//,
-    func: () => {
-      chrome.tabs.executeScript(
-        {
-          code: `(function(){
-            const ids = [];
-            const videos = document.querySelectorAll("[data-video-id]");
-            for (let i=0; i < videos.length; i++) {
-              const id = videos[i].getAttribute("data-video-id");
-              if (id) {
-                ids.push(id);
-              }
-            }
-            return ids;
-          })()`,
-        },
-        function (ids) {
-          console.log(ids);
-          ids = flatten(ids);
-          ids.forEach(function (video_id) {
-            const data_url = `https://api.svt.se/videoplayer-api/video/${video_id}`;
-            update_filename(`${video_id}.mp4`);
-            update_json_url(data_url);
-            console.log(data_url);
-            fetch(data_url).then(get_json).then(svt_callback).catch(api_error);
-          });
-          if (ids.length === 0) {
-            info('Hittade ingen video.');
-          }
-        },
-      );
+    permissions: isFirefox
+      ? {
+          origins: ['https://www.svt.se/'],
+        }
+      : null,
+    func: async (ret, url) => {
+      const doc = await fetchDOM(url);
+      const data = JSON.parse(doc.querySelector('#__NEXT_DATA__').textContent);
+      console.log(data);
+
+      const videoIds = Object.values(data.props.pageProps.__APOLLO_STATE__)
+        .map((v) => v.videoId)
+        .filter(Boolean);
+
+      for (const videoId of videoIds) {
+        const data_url = `https://api.svt.se/video/${videoId}`;
+        update_filename(`${videoId}.${options.default_video_file_extension}`);
+        update_json_url(data_url);
+        console.log(data_url);
+        fetch(data_url).then(get_json).then(svt_callback).catch(api_error);
+      }
+
+      if (videoIds.length === 0) {
+        info('Hittade ingen video.');
+      }
     },
   },
   {

--- a/extension/js/sites/svt.js
+++ b/extension/js/sites/svt.js
@@ -49,20 +49,14 @@
 import {
   api_error,
   info,
-  master_callback,
   options,
+  processPlaylist,
   subtitles,
   update_cmd,
   update_filename,
   update_json_url,
 } from '../popup.js';
-import {
-  $,
-  extract_filename,
-  fetchJson,
-  fetchNextData,
-  fetchText,
-} from '../utils.js';
+import { $, extract_filename, fetchJson, fetchNextData } from '../utils.js';
 
 function svt_callback(data) {
   console.log(data);
@@ -82,10 +76,7 @@ function svt_callback(data) {
     streams.appendChild(option);
 
     if (stream.format === 'hls') {
-      const base_url = stream.url.replace(/\/[^/]+$/, '/');
-      fetchText(stream.url)
-        .then(master_callback(data.contentDuration, base_url))
-        .catch(api_error);
+      processPlaylist(stream.url, data.contentDuration).catch(api_error);
     }
   }
 

--- a/extension/js/sites/tv4.js
+++ b/extension/js/sites/tv4.js
@@ -29,8 +29,8 @@ import {
 } from '../popup.js';
 import {
   $,
-  fetchDOM,
   fetchJson,
+  fetchNextData,
   fetchText,
   localStorageGetWithExpiry,
   localStorageSetWithExpiry,
@@ -146,10 +146,7 @@ export default [
   {
     re: /^https?:\/\/(?:www\.)?tv4\.se\.?\//,
     func: async (ret, url) => {
-      const doc = await fetchDOM(url);
-      const data = JSON.parse(doc.querySelector('#__NEXT_DATA__').textContent);
-      console.log(data);
-
+      const data = await fetchNextData(url);
       const videoIds = Object.values(data.props.apolloState)
         .filter((thing) => thing.type === 'clipvideo')
         .map((v) => v.id);

--- a/extension/js/sites/tv4.js
+++ b/extension/js/sites/tv4.js
@@ -13,18 +13,25 @@
 // https://vod.streaming.a2d.tv/93160d0a-55ab-4832-980e-ae790483b6ed/8e5f2ae0-47f3-11ed-986d-fd7a5f3ea464_20251151.ism/.m3u8
 //
 // Example URL: (login required)
-// https://www.tv4play.se/video/35e58882dbdd430da786/cornelia-jakobs
+// https://www.tv4play.se/video/8ff56dd8e591e1854af1/crossfire
 // Data URL: (valid X-Jwt token required)
-// https://playback2.a2d.tv/play/35e58882dbdd430da786?service=tv4play&device=browser&protocol=hls%2Cdash&drm=widevine&browser=MicrosoftEdge&capabilities=live-drm-adstitch-2%2Cyospace3
+// https://playback2.a2d.tv/play/8ff56dd8e591e1854af1?service=tv4play&device=browser&protocol=hls%2Cdash&drm=widevine&browser=GoogleChrome&capabilities=live-drm-adstitch-2%2Cyospace3
 
 import {
   api_error,
+  info,
   options,
+  tab_id,
   update_cmd,
   update_filename,
   update_json_url,
 } from '../popup.js';
-import { $, get_json } from '../utils.js';
+import {
+  $,
+  get_json,
+  localStorageGetWithExpiry,
+  localStorageSetWithExpiry,
+} from '../utils.js';
 
 function tv4play_asset_callback(data) {
   const media_url = `https://playback2.a2d.tv${data.mediaUri}`;
@@ -36,7 +43,6 @@ function tv4play_media_callback(data) {
   update_filename(
     `${data.metadata.title.trim()}.${options.default_video_file_extension}`,
   );
-  update_json_url(data.playbackItem.manifestUrl);
 
   const dropdown = $('#streams');
   const option = document.createElement('option');
@@ -56,58 +62,72 @@ function tv4_error(e) {
 export default [
   {
     re: /^https?:\/\/(?:www\.)?tv4play\.se\.?\/(?:video|program|klipp)\/([0-9a-f]+)/,
-    func: (ret) => {
+    func: async (ret) => {
       const video_id = ret[1];
       update_filename(`${video_id}.${options.default_video_file_extension}`);
 
-      chrome.tabs.executeScript(
-        {
-          code: `document.cookie.split(';').map(c => c.trim()).find(c => c.startsWith("tv4-refresh-token="))?.split("=")[1]`,
-        },
-        async function (refresh_tokens) {
-          const refresh_token = refresh_tokens[0];
+      let access_token = localStorageGetWithExpiry('tv4-access-token');
+      if (access_token && !access_token.startsWith('ey')) {
+        access_token = undefined;
+      }
 
-          // if there's a tv4-refresh-token then we always get the access token and include the X-Jwt header
-          // since some video clips do not require a token, we do not error if there isn't a refresh token
-          let access_token;
-          if (refresh_token) {
-            access_token = localStorageGetWithExpiry('tv4-access-token');
-            if (access_token === null) {
-              const access_token_request = await fetch(
-                'https://avod-auth-alb.a2d.tv/oauth/refresh',
-                {
-                  method: 'POST',
-                  body: JSON.stringify({ refresh_token }),
-                  headers: {
-                    'Content-Type': 'application/json',
-                  },
-                },
-              );
-              if (access_token_request.ok) {
-                const access_token_data = await access_token_request.json();
-                access_token = access_token_data.access_token;
-                localStorageSetWithExpiry(
-                  'tv4-access-token',
-                  access_token,
-                  4 * 3600 * 1000,
-                );
-              }
+      if (!access_token) {
+        const injectionResult = await chrome.scripting.executeScript({
+          target: { tabId: tab_id },
+          func: async () => {
+            const refresh_token = document.cookie
+              .split(';')
+              .map((c) => c.trim())
+              .find((c) => c.startsWith('tv4-refresh-token='))
+              ?.split('=')[1];
+            if (!refresh_token) {
+              return 'no refresh token';
             }
-          }
+            const response = await fetch(
+              'https://avod-auth-alb.a2d.tv/oauth/refresh',
+              {
+                method: 'POST',
+                credentials: 'omit',
+                mode: 'cors',
+                headers: {
+                  accept: 'application/json',
+                  'content-type': 'application/json',
+                },
+                body: JSON.stringify({ refresh_token, client_id: 'tv4-web' }),
+              },
+            );
+            if (!response.ok) {
+              return `error: ${response.status}`;
+            }
+            const access_token_data = await response.json();
+            return access_token_data.access_token;
+          },
+        });
+        console.log('injectionResult', injectionResult);
+        if (injectionResult[0].result.startsWith('ey')) {
+          access_token = injectionResult[0].result;
+          localStorageSetWithExpiry(
+            'tv4-access-token',
+            access_token,
+            4 * 3600 * 1000,
+          );
+        } else {
+          info('Nu gick något nog fel.. men vi försöker ändå.');
+        }
+      }
 
-          const metadata_url = `https://playback2.a2d.tv/play/${video_id}?service=tv4play&device=browser&protocol=hls%2Cdash&drm=widevine&browser=MicrosoftEdge&capabilities=live-drm-adstitch-2%2Cyospace3`;
-          fetch(metadata_url, {
-            headers: access_token
-              ? {
-                  'X-Jwt': `Bearer ${access_token}`,
-                }
-              : {},
-          })
-            .then(get_json)
-            .then(tv4play_media_callback)
-            .catch(tv4_error);
-        },
-      );
+      const metadata_url = `https://playback2.a2d.tv/play/${video_id}?service=tv4play&device=browser&protocol=hls%2Cdash&drm=widevine&browser=GoogleChrome&capabilities=live-drm-adstitch-2%2Cyospace3`;
+      update_json_url(metadata_url);
+      fetch(metadata_url, {
+        headers: access_token
+          ? {
+              'X-Jwt': `Bearer ${access_token}`,
+            }
+          : {},
+      })
+        .then(get_json)
+        .then(tv4play_media_callback)
+        .catch(tv4_error);
     },
   },
   {

--- a/extension/js/sites/tv4.js
+++ b/extension/js/sites/tv4.js
@@ -20,8 +20,8 @@
 import {
   api_error,
   info,
-  master_callback,
   options,
+  processPlaylist,
   tab_id,
   update_cmd,
   update_filename,
@@ -31,7 +31,6 @@ import {
   $,
   fetchJson,
   fetchNextData,
-  fetchText,
   localStorageGetWithExpiry,
   localStorageSetWithExpiry,
 } from '../utils.js';
@@ -53,10 +52,9 @@ function tv4play_media_callback(data, expand = false) {
   update_cmd();
 
   if (expand && data.playbackItem.type === 'hls') {
-    const base_url = data.playbackItem.manifestUrl.replace(/\/[^/]+$/, '/');
-    fetchText(data.playbackItem.manifestUrl)
-      .then(master_callback(data.contentDuration, base_url))
-      .catch(api_error);
+    processPlaylist(data.playbackItem.manifestUrl, data.contentDuration).catch(
+      api_error,
+    );
   }
 }
 

--- a/extension/js/sites/tv4.js
+++ b/extension/js/sites/tv4.js
@@ -80,67 +80,73 @@ export default [
       }
 
       if (!access_token) {
-        const injectionResult = await chrome.scripting.executeScript({
-          target: { tabId: tab_id },
-          func: async () => {
-            const refresh_token = document.cookie
-              .split(';')
-              .map((c) => c.trim())
-              .find((c) => c.startsWith('tv4-refresh-token='))
-              ?.split('=')[1];
-            if (!refresh_token) {
-              return { error: 'no refresh token' };
-            }
-            const response = await fetch(
-              'https://avod-auth-alb.a2d.tv/oauth/refresh',
-              {
-                method: 'POST',
-                credentials: 'omit',
-                mode: 'cors',
-                headers: {
-                  accept: 'application/json',
-                  'content-type': 'application/json',
+        try {
+          const injectionResult = await chrome.scripting.executeScript({
+            target: { tabId: tab_id },
+            func: async () => {
+              const refresh_token = document.cookie
+                .split(';')
+                .map((c) => c.trim())
+                .find((c) => c.startsWith('tv4-refresh-token='))
+                ?.split('=')[1];
+              if (!refresh_token) {
+                return { error: 'no refresh token' };
+              }
+              const response = await fetch(
+                'https://avod-auth-alb.a2d.tv/oauth/refresh',
+                {
+                  method: 'POST',
+                  credentials: 'omit',
+                  mode: 'cors',
+                  headers: {
+                    accept: 'application/json',
+                    'content-type': 'application/json',
+                  },
+                  body: JSON.stringify({ refresh_token, client_id: 'tv4-web' }),
                 },
-                body: JSON.stringify({ refresh_token, client_id: 'tv4-web' }),
-              },
-            );
-            if (!response.ok) {
-              return {
-                error: `Invalid response: ${
-                  response.status
-                } ${await response.text()}`,
-              };
-            }
-            const access_token_data = await response.json();
-            return { result: access_token_data.access_token };
-          },
-        });
-        console.debug('injectionResult', injectionResult);
-        if (injectionResult[0].error) {
-          throw injectionResult[0].error;
-        } else if (injectionResult[0].result === null) {
-          throw new Error('Script injection error.');
-        } else if (injectionResult[0].result.error) {
-          throw new Error(injectionResult[0].result.error);
+              );
+              if (!response.ok) {
+                return {
+                  error: `Invalid response: ${
+                    response.status
+                  } ${await response.text()}`,
+                };
+              }
+              const access_token_data = await response.json();
+              return { result: access_token_data.access_token };
+            },
+          });
+          console.debug('injectionResult', injectionResult);
+          if (injectionResult[0].error) {
+            throw injectionResult[0].error;
+          } else if (injectionResult[0].result === null) {
+            throw new Error('Script injection error.');
+          } else if (injectionResult[0].result.error) {
+            throw new Error(injectionResult[0].result.error);
+          }
+          access_token = injectionResult[0].result.result;
+          localStorageSetWithExpiry(
+            'tv4-access-token',
+            access_token,
+            4 * 3600 * 1000,
+          );
+        } catch (err) {
+          // Not all videos require a login, so even if there's an error above we still continue, just log the error in the console
+          console.error(err);
         }
-        const access_token = injectionResult[0].result.result;
-        localStorageSetWithExpiry(
-          'tv4-access-token',
-          access_token,
-          4 * 3600 * 1000,
-        );
       }
 
       const metadata_url = `https://playback2.a2d.tv/play/${video_id}?service=tv4play&device=browser&protocol=hls%2Cdash&drm=widevine&browser=GoogleChrome&capabilities=live-drm-adstitch-2%2Cyospace3`;
       update_json_url(metadata_url);
-      const data = await fetchJson(metadata_url, {
+      fetchJson(metadata_url, {
         headers: access_token
           ? {
               'X-Jwt': `Bearer ${access_token}`,
             }
           : {},
-      }).catch(tv4_error);
-      tv4play_media_callback(data, true);
+      })
+        .then((data) => tv4play_media_callback(data, true))
+        .catch(tv4_error);
     },
   },
   {

--- a/extension/js/sites/tv4.js
+++ b/extension/js/sites/tv4.js
@@ -120,7 +120,7 @@ export default [
           if (injectionResult[0].error) {
             throw injectionResult[0].error;
           } else if (injectionResult[0].result === null) {
-            throw new Error('Script injection error.');
+            throw new Error('Script error.');
           } else if (injectionResult[0].result.error) {
             throw new Error(injectionResult[0].result.error);
           }

--- a/extension/js/sites/ur.js
+++ b/extension/js/sites/ur.js
@@ -61,7 +61,11 @@ function ur_callback(domain, data) {
     dropdown.appendChild(option);
   }
 
-  let fn = `${program.title?.trim()}.${options.default_video_file_extension}`;
+  const ext =
+    program.format === 'video'
+      ? options.default_video_file_extension
+      : options.default_audio_file_extension;
+  let fn = `${program.title?.trim()}.${ext}`;
   if (program.seriesTitle) {
     fn = `${program.seriesTitle.trim()} - ${fn}`;
   }

--- a/extension/js/sites/ur.js
+++ b/extension/js/sites/ur.js
@@ -6,7 +6,7 @@
 // https://urplay.se/program/202840-smasagor-piraterna-och-regnbagsskatten
 
 import { api_error, options, update_cmd, update_filename } from '../popup.js';
-import { $, fetchDOM, get_json, isFirefox } from '../utils.js';
+import { $, fetchDOM, fetchJson } from '../utils.js';
 
 function ur_callback(data) {
   const program = data.program;
@@ -75,17 +75,11 @@ function ur_callback(data) {
 export default [
   {
     re: /^https?:\/\/(?:www\.)?urplay\.se\.?\//,
-    permissions: isFirefox
-      ? {
-          origins: ['https://urplay.se/'],
-        }
-      : null,
     func: async (ret, url) => {
       const doc = await fetchDOM(url);
       const data = JSON.parse(doc.querySelector('#__NEXT_DATA__').textContent);
       const lb_url = 'https://streaming-loadbalancer.ur.se/loadbalancer.json';
-      fetch(lb_url)
-        .then(get_json)
+      fetchJson(lb_url)
         .then(ur_callback(data.props.pageProps))
         .catch(api_error);
     },

--- a/extension/js/sites/ur.js
+++ b/extension/js/sites/ur.js
@@ -1,12 +1,11 @@
 // https://urplay.se/program/193738-amanda-langtar-sommaren
-// <script id="__NEXT_DATA__" type="application/json">{"props":...........}</script>
 // https://streaming10.ur.se/urplay/_definst_/mp4:193000-193999/193738-22.mp4/playlist.m3u8
 
 // https://urplay.se/program/175841-ur-samtiden-boy-s-own-den-brittiska-kulturrevolutionen
 // https://urplay.se/program/202840-smasagor-piraterna-och-regnbagsskatten
 
 import { api_error, options, update_cmd, update_filename } from '../popup.js';
-import { $, fetchDOM, fetchJson } from '../utils.js';
+import { $, fetchJson, fetchNextData } from '../utils.js';
 
 function ur_callback(data) {
   const program = data.program;
@@ -76,8 +75,7 @@ export default [
   {
     re: /^https?:\/\/(?:www\.)?urplay\.se\.?\//,
     func: async (ret, url) => {
-      const doc = await fetchDOM(url);
-      const data = JSON.parse(doc.querySelector('#__NEXT_DATA__').textContent);
+      const data = await fetchNextData(url);
       const lb_url = 'https://streaming-loadbalancer.ur.se/loadbalancer.json';
       fetchJson(lb_url)
         .then(ur_callback(data.props.pageProps))

--- a/extension/js/sites/ur.js
+++ b/extension/js/sites/ur.js
@@ -7,68 +7,66 @@
 import { api_error, options, update_cmd, update_filename } from '../popup.js';
 import { $, fetchJson, fetchNextData } from '../utils.js';
 
-function ur_callback(data) {
+function ur_callback(domain, data) {
   const program = data.program;
+  console.log('program', program);
 
-  return function (lb_data) {
-    const domain = lb_data.redirect;
-    const streams = [];
-    if (
-      program.streamingInfo.sweComplete &&
-      program.streamingInfo.sweComplete.hd
-    ) {
-      streams.push({
-        info: 'HD med undertexter',
-        url: `https://${domain}/${program.streamingInfo.sweComplete.hd.location}playlist.m3u8`,
-      });
-    }
-    if (program.streamingInfo.raw && program.streamingInfo.raw.hd) {
-      streams.push({
-        info: 'HD',
-        url: `https://${domain}/${program.streamingInfo.raw.hd.location}playlist.m3u8`,
-      });
-    }
-    if (
-      program.streamingInfo.sweComplete &&
-      program.streamingInfo.sweComplete.sd
-    ) {
-      streams.push({
-        info: 'SD med undertexter',
-        url: `https://${domain}/${program.streamingInfo.sweComplete.sd.location}playlist.m3u8`,
-      });
-    }
-    if (program.streamingInfo.raw) {
-      for (const [key, value] of Object.entries(program.streamingInfo.raw)) {
-        if (!value.location) {
-          continue;
-        }
-        const url = `https://${domain}/${value.location}playlist.m3u8`;
-        if (streams.some((s) => s.url === url)) {
-          continue;
-        }
-        streams.push({
-          info: key.toUpperCase(),
-          url: url,
-        });
+  const streams = [];
+  if (
+    program.streamingInfo.sweComplete &&
+    program.streamingInfo.sweComplete.hd
+  ) {
+    streams.push({
+      info: 'HD med undertexter',
+      url: `https://${domain}/${program.streamingInfo.sweComplete.hd.location}playlist.m3u8`,
+    });
+  }
+  if (program.streamingInfo.raw && program.streamingInfo.raw.hd) {
+    streams.push({
+      info: 'HD',
+      url: `https://${domain}/${program.streamingInfo.raw.hd.location}playlist.m3u8`,
+    });
+  }
+  if (
+    program.streamingInfo.sweComplete &&
+    program.streamingInfo.sweComplete.sd
+  ) {
+    streams.push({
+      info: 'SD med undertexter',
+      url: `https://${domain}/${program.streamingInfo.sweComplete.sd.location}playlist.m3u8`,
+    });
+  }
+  if (program.streamingInfo.raw) {
+    for (const [key, value] of Object.entries(program.streamingInfo.raw)) {
+      if (!value.location) {
+        continue;
       }
+      const url = `https://${domain}/${value.location}playlist.m3u8`;
+      if (streams.some((s) => s.url === url)) {
+        continue;
+      }
+      streams.push({
+        info: key.toUpperCase(),
+        url: url,
+      });
     }
-    console.log(streams);
+  }
+  console.log('stream', streams);
 
-    const dropdown = $('#streams');
-    for (const stream of streams) {
-      const option = document.createElement('option');
-      option.value = stream.url;
-      option.appendChild(document.createTextNode(stream.info));
-      dropdown.appendChild(option);
-    }
+  const dropdown = $('#streams');
+  for (const stream of streams) {
+    const option = document.createElement('option');
+    option.value = stream.url;
+    option.appendChild(document.createTextNode(stream.info));
+    dropdown.appendChild(option);
+  }
 
-    let fn = `${program.title?.trim()}.${options.default_video_file_extension}`;
-    if (program.seriesTitle) {
-      fn = `${program.seriesTitle.trim()} - ${fn}`;
-    }
-    update_filename(fn);
-    update_cmd();
-  };
+  let fn = `${program.title?.trim()}.${options.default_video_file_extension}`;
+  if (program.seriesTitle) {
+    fn = `${program.seriesTitle.trim()} - ${fn}`;
+  }
+  update_filename(fn);
+  update_cmd();
 }
 
 export default [
@@ -78,7 +76,7 @@ export default [
       const data = await fetchNextData(url);
       const lb_url = 'https://streaming-loadbalancer.ur.se/loadbalancer.json';
       fetchJson(lb_url)
-        .then(ur_callback(data.props.pageProps))
+        .then((lb_data) => ur_callback(lb_data.redirect, data.props.pageProps))
         .catch(api_error);
     },
   },

--- a/extension/js/utils.js
+++ b/extension/js/utils.js
@@ -72,17 +72,12 @@ export function $() {
   }
 }
 
-export function getDocumentTitle() {
-  return new Promise((resolve, reject) => {
-    chrome.tabs.executeScript(
-      {
-        code: `(function(){ return document.title; })()`,
-      },
-      (data) => {
-        resolve(data[0]);
-      },
-    );
+export async function getDocumentTitle(tab_id) {
+  const injectionResult = await chrome.scripting.executeScript({
+    target: { tabId: tab_id },
+    func: () => document.title,
   });
+  return injectionResult[0].result;
 }
 
 export async function fetchDOM(url) {

--- a/extension/js/utils.js
+++ b/extension/js/utils.js
@@ -79,6 +79,11 @@ export async function getDocumentTitle(tab_id) {
     target: { tabId: tab_id },
     func: () => document.title,
   });
+  if (injectionResult[0].error) {
+    throw injectionResult[0].error;
+  } else if (injectionResult[0].result === null) {
+    throw new Error('Script injection error.');
+  }
   return injectionResult[0].result;
 }
 
@@ -94,15 +99,26 @@ export async function fetchDOM(url, ...args) {
     func: async (...args) => {
       const response = await fetch(...args);
       if (!response.ok) {
-        throw new Error(
-          `Invalid response: ${response.status} ${await response.text()}`,
-        );
+        return {
+          error: `Invalid response: ${
+            response.status
+          } ${await response.text()}`,
+        };
       }
-      return response.text();
+      return { result: await response.text() };
     },
     args: [url, ...args],
   });
-  const body = injectionResult[0].result;
+  console.debug('injectionResult', injectionResult);
+  if (injectionResult[0].error) {
+    throw injectionResult[0].error;
+  } else if (injectionResult[0].result === null) {
+    throw new Error('Script injection error.');
+  } else if (injectionResult[0].result.error) {
+    throw new Error(injectionResult[0].result.error);
+  }
+
+  const body = injectionResult[0].result.result;
   const doc = new DOMParser().parseFromString(body, 'text/html');
   return doc;
 }
@@ -113,16 +129,25 @@ export async function fetchText(...args) {
     func: async (...args) => {
       const response = await fetch(...args);
       if (!response.ok) {
-        throw new Error(
-          `Invalid response: ${response.status} ${await response.text()}`,
-        );
+        return {
+          error: `Invalid response: ${
+            response.status
+          } ${await response.text()}`,
+        };
       }
-      return response.text();
+      return { result: await response.text() };
     },
     args,
   });
-  console.log('injectionResult', injectionResult);
-  return injectionResult[0].result;
+  console.debug('injectionResult', injectionResult);
+  if (injectionResult[0].error) {
+    throw injectionResult[0].error;
+  } else if (injectionResult[0].result === null) {
+    throw new Error('Script injection error.');
+  } else if (injectionResult[0].result.error) {
+    throw new Error(injectionResult[0].result.error);
+  }
+  return injectionResult[0].result.result;
 }
 
 export async function fetchJson(...args) {
@@ -131,16 +156,25 @@ export async function fetchJson(...args) {
     func: async (...args) => {
       const response = await fetch(...args);
       if (!response.ok) {
-        throw new Error(
-          `Invalid response: ${response.status} ${await response.text()}`,
-        );
+        return {
+          error: `Invalid response: ${
+            response.status
+          } ${await response.text()}`,
+        };
       }
-      return response.json();
+      return { result: await response.json() };
     },
     args,
   });
-  console.log('injectionResult', injectionResult);
-  return injectionResult[0].result;
+  console.debug('injectionResult', injectionResult);
+  if (injectionResult[0].error) {
+    throw injectionResult[0].error;
+  } else if (injectionResult[0].result === null) {
+    throw new Error('Script injection error.');
+  } else if (injectionResult[0].result.error) {
+    throw new Error(injectionResult[0].result.error);
+  }
+  return injectionResult[0].result.result;
 }
 
 export function extract_filename(url) {

--- a/extension/js/utils.js
+++ b/extension/js/utils.js
@@ -97,15 +97,19 @@ export async function fetchDOM(url, ...args) {
   const injectionResult = await chrome.scripting.executeScript({
     target: { tabId: tab_id },
     func: async (...args) => {
-      const response = await fetch(...args);
-      if (!response.ok) {
-        return {
-          error: `Invalid response: ${
-            response.status
-          } ${await response.text()}`,
-        };
+      try {
+        const response = await fetch(...args);
+        if (!response.ok) {
+          return {
+            error: `Invalid response: ${
+              response.status
+            } ${await response.text()}`,
+          };
+        }
+        return { result: await response.text() };
+      } catch (err) {
+        return { error: err.message };
       }
-      return { result: await response.text() };
     },
     args: [url, ...args],
   });
@@ -140,15 +144,19 @@ export async function fetchText(...args) {
   const injectionResult = await chrome.scripting.executeScript({
     target: { tabId: tab_id },
     func: async (...args) => {
-      const response = await fetch(...args);
-      if (!response.ok) {
-        return {
-          error: `Invalid response: ${
-            response.status
-          } ${await response.text()}`,
-        };
+      try {
+        const response = await fetch(...args);
+        if (!response.ok) {
+          return {
+            error: `Invalid response: ${
+              response.status
+            } ${await response.text()}`,
+          };
+        }
+        return { result: await response.text() };
+      } catch (err) {
+        return { error: err.message };
       }
-      return { result: await response.text() };
     },
     args,
   });
@@ -167,15 +175,19 @@ export async function fetchJson(...args) {
   const injectionResult = await chrome.scripting.executeScript({
     target: { tabId: tab_id },
     func: async (...args) => {
-      const response = await fetch(...args);
-      if (!response.ok) {
-        return {
-          error: `Invalid response: ${
-            response.status
-          } ${await response.text()}`,
-        };
+      try {
+        const response = await fetch(...args);
+        if (!response.ok) {
+          return {
+            error: `Invalid response: ${
+              response.status
+            } ${await response.text()}`,
+          };
+        }
+        return { result: await response.json() };
+      } catch (err) {
+        return { error: err.message };
       }
-      return { result: await response.json() };
     },
     args,
   });

--- a/extension/js/utils.js
+++ b/extension/js/utils.js
@@ -82,7 +82,7 @@ export async function getDocumentTitle(tab_id) {
   if (injectionResult[0].error) {
     throw injectionResult[0].error;
   } else if (injectionResult[0].result === null) {
-    throw new Error('Script injection error.');
+    throw new Error('Script error.');
   }
   return injectionResult[0].result;
 }
@@ -113,7 +113,7 @@ export async function fetchDOM(url, ...args) {
   if (injectionResult[0].error) {
     throw injectionResult[0].error;
   } else if (injectionResult[0].result === null) {
-    throw new Error('Script injection error.');
+    throw new Error('Script error.');
   } else if (injectionResult[0].result.error) {
     throw new Error(injectionResult[0].result.error);
   }
@@ -156,7 +156,7 @@ export async function fetchText(...args) {
   if (injectionResult[0].error) {
     throw injectionResult[0].error;
   } else if (injectionResult[0].result === null) {
-    throw new Error('Script injection error.');
+    throw new Error('Script error.');
   } else if (injectionResult[0].result.error) {
     throw new Error(injectionResult[0].result.error);
   }
@@ -183,7 +183,7 @@ export async function fetchJson(...args) {
   if (injectionResult[0].error) {
     throw injectionResult[0].error;
   } else if (injectionResult[0].result === null) {
-    throw new Error('Script injection error.');
+    throw new Error('Script error.');
   } else if (injectionResult[0].result.error) {
     throw new Error(injectionResult[0].result.error);
   }

--- a/extension/js/utils.js
+++ b/extension/js/utils.js
@@ -213,19 +213,3 @@ export function parse_pt(pt) {
   }
   return duration;
 }
-
-export function get_json(response) {
-  console.log(response);
-  if (response.ok) {
-    return response.json();
-  }
-  throw response;
-}
-
-export function get_text(response) {
-  console.log(response);
-  if (response.ok) {
-    return response.text();
-  }
-  throw response;
-}

--- a/extension/js/utils.js
+++ b/extension/js/utils.js
@@ -123,6 +123,19 @@ export async function fetchDOM(url, ...args) {
   return doc;
 }
 
+export async function fetchNextData(url) {
+  // We always want to perform a network request rather than executing a script to pull the page's data, since that
+  // has a chance of fetching old data if the user has navigated around on the website before opening the extension.
+  const doc = await fetchDOM(url);
+  const nextData = doc.querySelector('#__NEXT_DATA__');
+  if (!nextData) {
+    throw new Error('__NEXT_DATA__ not found on page');
+  }
+  const data = JSON.parse(nextData.textContent);
+  console.debug(data);
+  return data;
+}
+
 export async function fetchText(...args) {
   const injectionResult = await chrome.scripting.executeScript({
     target: { tabId: tab_id },

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Privatkopiera",
-  "version": "0.3.10",
+  "version": "0.4.0",
   "description": "Ladda ned från play-tjänster. Kräver ffmpeg.",
   "homepage_url": "https://stefansundin.github.io/privatkopiera/",
   "author": "Stefan Sundin",
@@ -10,7 +10,7 @@
     "48": "img/icon48.png",
     "128": "img/icon128.png"
   },
-  "browser_action": {
+  "action": {
     "default_icon": {
       "19": "img/icon19.png",
       "38": "img/icon38.png"
@@ -22,11 +22,15 @@
     "page": "options.html"
   },
   "permissions": [
-    "activeTab"
+    "activeTab",
+    "scripting"
   ],
   "optional_permissions": [
-    "downloads",
+    "downloads"
+  ],
+  "optional_host_permissions": [
     "https://psapi.nrk.no/",
     "https://production.dr-massive.com/"
-  ]
+  ],
+  "minimum_chrome_version": "102"
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -28,9 +28,5 @@
   "optional_permissions": [
     "downloads"
   ],
-  "optional_host_permissions": [
-    "https://psapi.nrk.no/",
-    "https://production.dr-massive.com/"
-  ],
   "minimum_chrome_version": "102"
 }

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8">
+  <title>Privatkopiera</title>
   <link rel="stylesheet" href="css/bootstrap.min.css">
   <link rel="stylesheet" href="css/bootstrap-overrides.css">
   <link rel="stylesheet" href="css/popup.css">

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -30,7 +30,8 @@
     "https://psapi.nrk.no/",
     "https://production.dr-massive.com/",
     "https://sverigesradio.se/",
-    "https://urplay.se/"
+    "https://urplay.se/",
+    "https://www.svt.se/"
   ],
   "browser_specific_settings": {
     "gecko": {

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -26,12 +26,7 @@
     "scripting"
   ],
   "optional_permissions": [
-    "downloads",
-    "https://psapi.nrk.no/",
-    "https://production.dr-massive.com/",
-    "https://sverigesradio.se/",
-    "https://urplay.se/",
-    "https://www.svt.se/"
+    "downloads"
   ],
   "browser_specific_settings": {
     "gecko": {

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Privatkopiera",
-  "version": "0.3.10",
+  "version": "0.4.0",
   "description": "Ladda ned från play-tjänster. Kräver ffmpeg.",
   "homepage_url": "https://stefansundin.github.io/privatkopiera/",
   "author": "Stefan Sundin",
@@ -10,7 +10,7 @@
     "48": "img/icon48.png",
     "128": "img/icon128.png"
   },
-  "browser_action": {
+  "action": {
     "default_icon": {
       "19": "img/icon19.png",
       "38": "img/icon38.png"
@@ -22,7 +22,8 @@
     "page": "options.html"
   },
   "permissions": [
-    "activeTab"
+    "activeTab",
+    "scripting"
   ],
   "optional_permissions": [
     "downloads",
@@ -34,7 +35,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "privatkopiera@firefox.stefansundin.com",
-      "strict_min_version": "75.0"
+      "strict_min_version": "109.0"
     }
   }
 }


### PR DESCRIPTION
Converts the extension to Manifest Version 3. The great thing with this upgrade is that scripts executed on the page can now be async, which is necessary to fix https://github.com/stefansundin/privatkopiera/issues/185.

All network requests are now fetched through the host page to avoid having to ask for any host permissions in the optional permissions. This should also help if any of the websites randomly change their CORS permissiveness.

This PR also fixes svt.se and tv4.se videos, but that fix is probably very brittle and needs to be improved further in the future.

I have branched off the current `main` branch into a new `mv2` branch which will be preserved in case anyone wants to easily check out that code. It contains a lot of improvements made pre-MV3 that aren't in v0.3.10. https://github.com/stefansundin/privatkopiera/tree/mv2

This just needs some more testing before merging and releasing.

New minimum browser versions:
- Chrome: 102
  - Seems to work down to Chrome 98 but will keep the minimum at 102 because it seems like lots of MV3 bugs were fixed in 102. I originally needed `optional_host_permissions` in Chrome 102 but that is no longer used.
- Firefox: 109
