### PR TITLE
NRK: Add option to use accessToken for manifest fetching

### DIFF
--- a/extension/js/defaultOptions.js
+++ b/extension/js/defaultOptions.js
@@ -3,6 +3,7 @@ export default {
   default_audio_file_extension: 'm4a',
   svt_video_format: ['hls-cmaf-full'],
   add_source_id_to_filename: true,
+  add_authentication_to_nrk_requests: false,
   ffmpeg_command: 'ffmpeg',
   output_path: '',
 };

--- a/extension/js/options.js
+++ b/extension/js/options.js
@@ -6,6 +6,7 @@ const options = {
   default_audio_file_extension: localStorage.default_audio_file_extension || defaultOptions.default_audio_file_extension,
   svt_video_format: localStorage.svt_video_format?.split(',') || defaultOptions.svt_video_format,
   add_source_id_to_filename: localStorage.add_source_id_to_filename ? localStorage.add_source_id_to_filename === 'true' : defaultOptions.add_source_id_to_filename,
+  add_authentication_to_nrk_requests: localStorage.add_authentication_to_nrk_requests ? localStorage.add_authentication_to_nrk_requests === 'true' : defaultOptions.add_authentication_to_nrk_requests,
   ffmpeg_command: localStorage.ffmpeg_command || defaultOptions.ffmpeg_command,
   output_path: localStorage.output_path || defaultOptions.output_path,
 };
@@ -51,6 +52,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const svt_video_format_input = document.getElementById('svt_video_format');
   const ffmpeg_command_input = document.getElementById('ffmpeg_command');
   const add_source_id_to_filename_input = document.getElementById('add_source_id_to_filename');
+  const add_authentication_to_nrk_requests = document.getElementById('add_authentication_to_nrk_requests');
   const output_path_input = document.getElementById('output_path');
   const save_button = document.getElementById('save');
 
@@ -58,6 +60,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   default_audio_file_extension_input.value = options.default_audio_file_extension;
   svt_video_format_input.value = options.svt_video_format.join(',');
   add_source_id_to_filename_input.checked = options.add_source_id_to_filename;
+  add_authentication_to_nrk_requests.checked = options.add_authentication_to_nrk_requests;
   ffmpeg_command_input.value = options.ffmpeg_command;
   output_path_input.value = options.output_path;
 
@@ -85,6 +88,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     localStorage.default_video_file_extension = default_video_file_extension_input.value.trim();
     localStorage.default_audio_file_extension = default_audio_file_extension_input.value.trim();
     localStorage.add_source_id_to_filename = add_source_id_to_filename_input.checked;
+    localStorage.add_authentication_to_nrk_requests = add_authentication_to_nrk_requests.checked;
     localStorage.svt_video_format = dedupe(svt_video_format_input.value.split(',').map(format => format.trim())).join(',');
     localStorage.ffmpeg_command = ffmpeg_command_input.value;
 
@@ -123,6 +127,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     delete localStorage.default_audio_file_extension;
     delete localStorage.svt_video_format;
     delete localStorage.add_source_id_to_filename;
+    delete localStorage.add_authentication_to_nrk_requests;
     delete localStorage.ffmpeg_command;
     delete localStorage.output_path;
 
@@ -130,6 +135,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     default_audio_file_extension_input.value = defaultOptions.default_audio_file_extension;
     svt_video_format_input.value = defaultOptions.svt_video_format.join(',');
     add_source_id_to_filename_input.checked = defaultOptions.add_source_id_to_filename;
+    add_authentication_to_nrk_requests.checked = defaultOptions.add_authentication_to_nrk_requests;
     ffmpeg_command_input.value = defaultOptions.ffmpeg_command;
     output_path_input.value = defaultOptions.output_path;
   });
@@ -142,6 +148,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     default_audio_file_extension_input.parentElement.nextElementSibling.classList.add('d-none');
     add_source_id_to_filename_input.parentElement.classList.add('d-none');
     add_source_id_to_filename_input.parentElement.nextElementSibling.classList.add('d-none');
+    add_authentication_to_nrk_requests.parentElement.classList.add('d-none');
+    add_authentication_to_nrk_requests.parentElement.nextElementSibling.classList.add('d-none');
     ffmpeg_command_input.parentElement.classList.add('d-none');
     ffmpeg_command_input.parentElement.nextElementSibling.classList.add('d-none');
     output_path_input.parentElement.classList.add('d-none');

--- a/extension/js/popup.js
+++ b/extension/js/popup.js
@@ -24,6 +24,7 @@ export const options = {
   default_audio_file_extension: localStorage.default_audio_file_extension || defaultOptions.default_audio_file_extension,
   svt_video_format: localStorage.svt_video_format?.split(',') || defaultOptions.svt_video_format,
   add_source_id_to_filename: localStorage.add_source_id_to_filename ? localStorage.add_source_id_to_filename === 'true' : defaultOptions.add_source_id_to_filename,
+  add_authentication_to_nrk_requests: localStorage.add_authentication_to_nrk_requests ? localStorage.add_authentication_to_nrk_requests === 'true' : defaultOptions.add_authentication_to_nrk_requests,
   ffmpeg_command: localStorage.ffmpeg_command || defaultOptions.ffmpeg_command,
   output_path: localStorage.output_path || defaultOptions.output_path,
 };

--- a/extension/js/sites/nrk.js
+++ b/extension/js/sites/nrk.js
@@ -27,11 +27,36 @@ import {
 import {
   $,
   extractFilename,
-  fetchAccessToken,
   fetchJson,
   fetchPageData,
   getDocumentTitle,
+  getTab,
 } from '../utils.js';
+
+async function fetchAccessToken() {
+  const tab = await getTab();
+  const injectionResult = await chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    func: async () => {
+      try {
+        const clientState = JSON.parse(localStorage.getItem('nrk-login-client-state'));
+
+        return clientState?.sessionData?.accessToken ?? null;
+      } catch (err) {
+        return { error: err.message };
+      }
+    },
+  });
+  console.debug('injectionResult', injectionResult);
+  if (injectionResult[0].error) {
+    throw injectionResult[0].error;
+  } else if (injectionResult[0].result === null) {
+    throw new Error('Script error.');
+  } else if (injectionResult[0].result.error) {
+    throw new Error(injectionResult[0].result.error);
+  }
+  return injectionResult[0].result;
+}
 
 async function callback(data) {
   console.log(data);

--- a/extension/js/utils.js
+++ b/extension/js/utils.js
@@ -145,6 +145,31 @@ export async function fetchText(...args) {
   return injectionResult[0].result.result;
 }
 
+export async function fetchAccessToken() {
+  const tab = await getTab();
+  const injectionResult = await chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    func: async () => {
+      try {
+        const clientState = JSON.parse(localStorage.getItem('nrk-login-client-state'));
+
+        return clientState?.sessionData?.accessToken ?? null;
+      } catch (err) {
+        return { error: err.message };
+      }
+    },
+  });
+  console.debug('injectionResult', injectionResult);
+  if (injectionResult[0].error) {
+    throw injectionResult[0].error;
+  } else if (injectionResult[0].result === null) {
+    throw new Error('Script error.');
+  } else if (injectionResult[0].result.error) {
+    throw new Error(injectionResult[0].result.error);
+  }
+  return injectionResult[0].result;
+}
+
 export async function fetchJson(...args) {
   const tab = await getTab();
   const injectionResult = await chrome.scripting.executeScript({

--- a/extension/js/utils.js
+++ b/extension/js/utils.js
@@ -145,31 +145,6 @@ export async function fetchText(...args) {
   return injectionResult[0].result.result;
 }
 
-export async function fetchAccessToken() {
-  const tab = await getTab();
-  const injectionResult = await chrome.scripting.executeScript({
-    target: { tabId: tab.id },
-    func: async () => {
-      try {
-        const clientState = JSON.parse(localStorage.getItem('nrk-login-client-state'));
-
-        return clientState?.sessionData?.accessToken ?? null;
-      } catch (err) {
-        return { error: err.message };
-      }
-    },
-  });
-  console.debug('injectionResult', injectionResult);
-  if (injectionResult[0].error) {
-    throw injectionResult[0].error;
-  } else if (injectionResult[0].result === null) {
-    throw new Error('Script error.');
-  } else if (injectionResult[0].result.error) {
-    throw new Error(injectionResult[0].result.error);
-  }
-  return injectionResult[0].result;
-}
-
 export async function fetchJson(...args) {
   const tab = await getTab();
   const injectionResult = await chrome.scripting.executeScript({

--- a/extension/options.html
+++ b/extension/options.html
@@ -76,6 +76,17 @@
       <code class="text-nowrap">[SVT 8M6ZxZ4]</code> för videon från https://www.svtplay.se/video/8M6ZxZ4
     </p>
 
+    <div class="form-check">
+      <input class="form-check-input" type="checkbox" id="add_authentication_to_nrk_requests">
+      <label class="form-check-label" for="add_authentication_to_nrk_requests">
+        &nbsp;Lägg till autentisering till NRK-förfrågningar
+      </label>
+    </div>
+    <p>
+      Om du är inloggad på NRK, läggs en autentiseringstoken till i förfrågningarna för att hämta videor. Detta gör att
+      du kan ladda ner från NRK inom EEA när du är inloggad och inte är i Norge.
+    </p>
+
     <div class="input-group">
       <span class="input-group-text">
         <label for="ffmpeg_command">


### PR DESCRIPTION
Försöker man anropa manifest-urlen idag för georestricted innehåll så får man en felkod;

```
Error: Ikke tilgjengelig utenfor Norge
```

Den här PRen lägger till:

- Inställning för att tillåta att tillägget läser ut accessToken från localStorage på NRK
- Om tillstånd finns; slänger denna på requesten för att kunna hämta manifestet med användarens inlogg

Detta tillåter att ladda ner innehåll som är låst till Norge inom EES om man har ett konto på NRK som är godkänt för att spela innehåll i utlandet. Kravet är norsk personnummer ~ ansluten med norsk BankID till NRK, vilket råkar vara mitt fall!